### PR TITLE
Using 2.8.3 Default Hadoop that ships with Druid for Sonata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <netty4.version>4.1.30.Final</netty4.version>
         <slf4j.version>1.7.12</slf4j.version>
         <!-- If compiling with different hadoop version also modify default hadoop coordinates in TaskConfig.java -->
-        <hadoop.compile.version>2.6.0</hadoop.compile.version>
+        <hadoop.compile.version>2.8.3</hadoop.compile.version>
         <hive.version>2.0.0</hive.version>
         <powermock.version>1.6.6</powermock.version>
         <aws.sdk.version>1.11.199</aws.sdk.version>


### PR DESCRIPTION
Hadoop S3A support is prod ready from Hadoop2.7 . 

Reverting  back to the default hadoop version that ships with Druid.