### PR TITLE
0.13.0.6 incubating lyft

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/aws-common/pom.xml
+++ b/aws-common/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/aws-common/pom.xml
+++ b/aws-common/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
   </parent>
 
   <prerequisites>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
   </parent>
 
   <prerequisites>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/extendedset/pom.xml
+++ b/extendedset/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
   </parent>
 
   <dependencies>

--- a/extendedset/pom.xml
+++ b/extendedset/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
   </parent>
 
   <dependencies>

--- a/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/azure-extensions/pom.xml
+++ b/extensions-contrib/azure-extensions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/azure-extensions/pom.xml
+++ b/extensions-contrib/azure-extensions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/cassandra-storage/pom.xml
+++ b/extensions-contrib/cassandra-storage/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/cassandra-storage/pom.xml
+++ b/extensions-contrib/cassandra-storage/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/cloudfiles-extensions/pom.xml
+++ b/extensions-contrib/cloudfiles-extensions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/cloudfiles-extensions/pom.xml
+++ b/extensions-contrib/cloudfiles-extensions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/distinctcount/pom.xml
+++ b/extensions-contrib/distinctcount/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/distinctcount/pom.xml
+++ b/extensions-contrib/distinctcount/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/druid-rocketmq/pom.xml
+++ b/extensions-contrib/druid-rocketmq/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/druid-rocketmq/pom.xml
+++ b/extensions-contrib/druid-rocketmq/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/google-extensions/pom.xml
+++ b/extensions-contrib/google-extensions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/google-extensions/pom.xml
+++ b/extensions-contrib/google-extensions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/graphite-emitter/pom.xml
+++ b/extensions-contrib/graphite-emitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/graphite-emitter/pom.xml
+++ b/extensions-contrib/graphite-emitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/influx-extensions/pom.xml
+++ b/extensions-contrib/influx-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/influx-extensions/pom.xml
+++ b/extensions-contrib/influx-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/kafka-eight-simpleConsumer/pom.xml
+++ b/extensions-contrib/kafka-eight-simpleConsumer/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/kafka-eight-simpleConsumer/pom.xml
+++ b/extensions-contrib/kafka-eight-simpleConsumer/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/materialized-view-maintenance/pom.xml
+++ b/extensions-contrib/materialized-view-maintenance/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/materialized-view-maintenance/pom.xml
+++ b/extensions-contrib/materialized-view-maintenance/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/materialized-view-selection/pom.xml
+++ b/extensions-contrib/materialized-view-selection/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/materialized-view-selection/pom.xml
+++ b/extensions-contrib/materialized-view-selection/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/opentsdb-emitter/pom.xml
+++ b/extensions-contrib/opentsdb-emitter/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opentsdb-emitter/pom.xml
+++ b/extensions-contrib/opentsdb-emitter/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/orc-extensions/pom.xml
+++ b/extensions-contrib/orc-extensions/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/orc-extensions/pom.xml
+++ b/extensions-contrib/orc-extensions/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/rabbitmq/pom.xml
+++ b/extensions-contrib/rabbitmq/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/rabbitmq/pom.xml
+++ b/extensions-contrib/rabbitmq/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/redis-cache/pom.xml
+++ b/extensions-contrib/redis-cache/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/redis-cache/pom.xml
+++ b/extensions-contrib/redis-cache/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/sqlserver-metadata-storage/pom.xml
+++ b/extensions-contrib/sqlserver-metadata-storage/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/sqlserver-metadata-storage/pom.xml
+++ b/extensions-contrib/sqlserver-metadata-storage/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/statsd-emitter/pom.xml
+++ b/extensions-contrib/statsd-emitter/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/statsd-emitter/pom.xml
+++ b/extensions-contrib/statsd-emitter/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/thrift-extensions/pom.xml
+++ b/extensions-contrib/thrift-extensions/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/thrift-extensions/pom.xml
+++ b/extensions-contrib/thrift-extensions/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/time-min-max/pom.xml
+++ b/extensions-contrib/time-min-max/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/time-min-max/pom.xml
+++ b/extensions-contrib/time-min-max/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-contrib/virtual-columns/pom.xml
+++ b/extensions-contrib/virtual-columns/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-contrib/virtual-columns/pom.xml
+++ b/extensions-contrib/virtual-columns/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/druid-basic-security/pom.xml
+++ b/extensions-core/druid-basic-security/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/druid-basic-security/pom.xml
+++ b/extensions-core/druid-basic-security/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/druid-bloom-filter/pom.xml
+++ b/extensions-core/druid-bloom-filter/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/druid-bloom-filter/pom.xml
+++ b/extensions-core/druid-bloom-filter/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/histogram/pom.xml
+++ b/extensions-core/histogram/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/histogram/pom.xml
+++ b/extensions-core/histogram/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/kafka-eight/pom.xml
+++ b/extensions-core/kafka-eight/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/kafka-eight/pom.xml
+++ b/extensions-core/kafka-eight/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/kafka-extraction-namespace/pom.xml
+++ b/extensions-core/kafka-extraction-namespace/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/kafka-extraction-namespace/pom.xml
+++ b/extensions-core/kafka-extraction-namespace/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/lookups-cached-global/pom.xml
+++ b/extensions-core/lookups-cached-global/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/lookups-cached-global/pom.xml
+++ b/extensions-core/lookups-cached-global/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/lookups-cached-single/pom.xml
+++ b/extensions-core/lookups-cached-single/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/lookups-cached-single/pom.xml
+++ b/extensions-core/lookups-cached-single/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/mysql-metadata-storage/pom.xml
+++ b/extensions-core/mysql-metadata-storage/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/mysql-metadata-storage/pom.xml
+++ b/extensions-core/mysql-metadata-storage/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-core/postgresql-metadata-storage/pom.xml
+++ b/extensions-core/postgresql-metadata-storage/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/postgresql-metadata-storage/pom.xml
+++ b/extensions-core/postgresql-metadata-storage/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/s3-extensions/pom.xml
+++ b/extensions-core/s3-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/s3-extensions/pom.xml
+++ b/extensions-core/s3-extensions/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-core/simple-client-sslcontext/pom.xml
+++ b/extensions-core/simple-client-sslcontext/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-core/simple-client-sslcontext/pom.xml
+++ b/extensions-core/simple-client-sslcontext/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/extensions-core/stats/pom.xml
+++ b/extensions-core/stats/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions-core/stats/pom.xml
+++ b/extensions-core/stats/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hll/pom.xml
+++ b/hll/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <artifactId>druid-hll</artifactId>

--- a/hll/pom.xml
+++ b/hll/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <artifactId>druid-hll</artifactId>

--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
@@ -488,7 +488,7 @@ public class JobHelper
                   progressable
               )) {
                 HadoopDruidIndexerConfig.JSON_MAPPER.writeValue(descriptorOut, segment);
-                descriptorOut.flush();
+                // descriptorOut.flush();
               }
             }
             catch (RuntimeException | IOException ex) {

--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <properties>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <properties>

--- a/java-util/pom.xml
+++ b/java-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <artifactId>java-util</artifactId>

--- a/java-util/pom.xml
+++ b/java-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <artifactId>java-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
     <packaging>pom</packaging>
 
     <name>Druid</name>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <netty4.version>4.1.30.Final</netty4.version>
         <slf4j.version>1.7.12</slf4j.version>
         <!-- If compiling with different hadoop version also modify default hadoop coordinates in TaskConfig.java -->
-        <hadoop.compile.version>2.6.0</hadoop.compile.version>
+        <hadoop.compile.version>2.8.3</hadoop.compile.version>
         <hive.version>2.0.0</hive.version>
         <powermock.version>1.6.6</powermock.version>
         <aws.sdk.version>1.11.199</aws.sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
     <packaging>pom</packaging>
 
     <name>Druid</name>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.4-incubating-lyft</version>
+        <version>0.13.0.5-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.druid</groupId>
         <artifactId>druid</artifactId>
-        <version>0.13.0.5-incubating-lyft</version>
+        <version>0.13.0.6-incubating-lyft</version>
     </parent>
 
     <dependencies>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.5-incubating-lyft</version>
+    <version>0.13.0.6-incubating-lyft</version>
   </parent>
 
   <dependencies>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.13.0.4-incubating-lyft</version>
+    <version>0.13.0.5-incubating-lyft</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
This Version of Druid is to support Hadoop Batch Ingestion to Sonata Hive Clusters(Hadoop 2.9.2) 

Changes: 
1. Revering back to default Hadoop Version 2.8.3 that is shipped with Druid 0.13-incubating. Hadoop Supports backward compatibility with clients so 2.8.3 client works with server version 2.9
2. This Patch : https://github.com/apache/druid/pull/6748 is needed to support S3 deep storage from hadoop Jobs. Since its a 1 line code change , made the change locally to JobHelper. This patch has been merged with 0.14 Version of Druid. 
3. Updated the poms to 13.0.6 

