### PR TITLE
Removed the hortonworks repo from the ambari-metrics-emitter extensio…

### DIFF
--- a/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -80,11 +80,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <id>hortonworks</id>
-      <name>hortonworks</name>
-      <url>http://repo.hortonworks.com/content/repositories/releases</url>
-    </repository>
-  </repositories>
 </project>


### PR DESCRIPTION
…n, it will fall back to apache repo (which has all the artifacts)

The root cause is that hortonworks maven repo has purged the older library dependencies. We can remove this repo override so it automatically falls back to the Apache repo (which has all the dependencies).